### PR TITLE
fpga_make.sh: /bin/sh -> /bin/bash

### DIFF
--- a/src/verilog/rtl/fpga_make.sh
+++ b/src/verilog/rtl/fpga_make.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ##Copy the *_defintitions file into all the file in the folder
 


### PR DESCRIPTION
Since this script uses nonstandard "bashisms" (`[[ ]]`) and is called directly as `./fpga_make.sh` it should begin with `#!/bin/bash` rather than `#!/bin/sh` for systems in which `bash` is not the default shell.